### PR TITLE
Add option to calculate lux value without floating point operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ fn main() {
         }
 
         let lux_val = sensor.get_lux_data().unwrap();
-        println!("LTR303 current lux phys: {}", lux_val.lux_phys);
+        println!("LTR303 current lux phys: {}", lux_val.lux_phys());
     }
 }
 ```
@@ -82,7 +82,7 @@ fn main() {
         }
 
         let lux_val = ltr303.get_lux_data().unwrap();
-        println!("LTR303 current lux phys: {}", lux_val.lux_phys);
+        println!("LTR303 current lux phys: {}", lux_val.lux_phys());
 
         FreeRtos.delay_ms(3000_u32);
     }

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ fn main() {
         }
 
         let lux_val = sensor.get_lux_data().unwrap();
-        println!("LTR303 current lux phys: {}", lux_val.lux_phys());
+        println!("LTR303 current lux phys: {}", lux_val.millilux_phys() as f32 / 1000.0);
     }
 }
 ```
@@ -82,7 +82,7 @@ fn main() {
         }
 
         let lux_val = ltr303.get_lux_data().unwrap();
-        println!("LTR303 current lux phys: {}", lux_val.lux_phys());
+        println!("LTR303 current millilux phys: {}", lux_val.millilux_phys());
 
         FreeRtos.delay_ms(3000_u32);
     }

--- a/src/fields.rs
+++ b/src/fields.rs
@@ -14,19 +14,6 @@ pub enum Gain {
     Gain96x = 0x07,
 }
 
-impl From<Gain> for f32 {
-    fn from(val: Gain) -> Self {
-        match val {
-            Gain::Gain1x => 1.0,
-            Gain::Gain2x => 2.0,
-            Gain::Gain4x => 4.0,
-            Gain::Gain8x => 8.0,
-            Gain::Gain48x => 48.0,
-            Gain::Gain96x => 96.0,
-        }
-    }
-}
-
 #[derive(Debug, Clone, Copy, PartialEq, FromPrimitive, ToPrimitive)]
 pub enum MeasurementRate {
     Ms50 = 0x00,
@@ -47,22 +34,6 @@ pub enum IntegrationTime {
     Ms250 = 0x05,
     Ms300 = 0x06,
     Ms350 = 0x07,
-}
-
-impl From<IntegrationTime> for f32 {
-    // See: https://github.com/aniketpalu/LTR303/blob/main/LTR-303%20329_Appendix%20A%20Ver_1.0_22%20Feb%202013.pdf
-    fn from(val: IntegrationTime) -> Self {
-        match val {
-            IntegrationTime::Ms50 => 0.5,
-            IntegrationTime::Ms100 => 1.0,
-            IntegrationTime::Ms150 => 1.5,
-            IntegrationTime::Ms200 => 2.0,
-            IntegrationTime::Ms250 => 2.5,
-            IntegrationTime::Ms300 => 3.0,
-            IntegrationTime::Ms350 => 3.5,
-            IntegrationTime::Ms400 => 4.0,
-        }
-    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, FromPrimitive, ToPrimitive)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,7 +46,7 @@
 //! while sensor.data_ready().unwrap() != true {}
 //!
 //! let lux_val = sensor.get_lux_data().unwrap();
-//! println!("LTR303 current lux phys: {}", lux_val.lux_phys());
+//! println!("LTR303 current lux phys: {}", lux_val.millilux_phys() as f32 / 1000.0);
 //! ```
 //!
 #![no_std]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,7 +46,7 @@
 //! while sensor.data_ready().unwrap() != true {}
 //!
 //! let lux_val = sensor.get_lux_data().unwrap();
-//! println!("LTR303 current lux phys: {}", lux_val.lux_phys);
+//! println!("LTR303 current lux phys: {}", lux_val.lux_phys());
 //! ```
 //!
 #![no_std]

--- a/src/types.rs
+++ b/src/types.rs
@@ -65,7 +65,7 @@ fn raw_to_lux(ch1_data: u16, ch0_data: u16, gain: Gain, itime: IntegrationTime) 
 }
 
 fn raw_to_lux_u32(ch1_data: u16, ch0_data: u16, gain: Gain, itime: IntegrationTime) -> u32 {
-    let ratio = ch1_data as u32 * 1000 / (ch0_data as u32 + ch1_data as u32);
+    let ratio = (ch1_data as u32 * 1000).checked_div(ch0_data as u32 + ch1_data as u32);
     let als_gain = match gain {
         Gain::Gain1x => 1,
         Gain::Gain2x => 2,
@@ -89,9 +89,9 @@ fn raw_to_lux_u32(ch1_data: u16, ch0_data: u16, gain: Gain, itime: IntegrationTi
 
     // scaled 10000x
     let factors = match ratio {
-        0..=449 => (17743, 11059),
-        450..=639 => (42785, -19548),
-        640..=849 => (5926, 1185),
+        Some(0..=449) => (17743, 11059),
+        Some(450..=639) => (42785, -19548),
+        Some(640..=849) => (5926, 1185),
         _ => (0, 0),
     };
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -26,20 +26,9 @@ impl LuxData {
         &self.lux_raw
     }
 
-    /// Value in Lux.
-    pub fn lux_phys(&self) -> f32 {
-        raw_to_lux(
-            self.lux_raw.ch1_raw,
-            self.lux_raw.ch0_raw,
-            self.gain,
-            self.integration_time,
-        )
-    }
-
-    /// Value in milli-Lux. Useful on platforms that do not have a floating
-    /// point unit.
-    pub fn lux_phys_u32(&self) -> u32 {
-        raw_to_lux_u32(
+    /// Value in milli-Lux.
+    pub fn millilux_phys(&self) -> u32 {
+        raw_to_millilux(
             self.lux_raw.ch1_raw,
             self.lux_raw.ch0_raw,
             self.gain,
@@ -48,23 +37,8 @@ impl LuxData {
     }
 }
 
-fn raw_to_lux(ch1_data: u16, ch0_data: u16, gain: Gain, itime: IntegrationTime) -> f32 {
-    let ratio = ch1_data as f32 / (ch0_data as f32 + ch1_data as f32);
-    let als_gain: f32 = gain.into();
-    let int_time: f32 = itime.into();
-
-    if ratio < 0.45 {
-        ((1.7743 * f32::from(ch0_data)) + (1.1059 * f32::from(ch1_data))) / als_gain / int_time
-    } else if (0.45..0.64).contains(&ratio) {
-        ((4.2785 * f32::from(ch0_data)) - (1.9548 * f32::from(ch1_data))) / als_gain / int_time
-    } else if (0.64..0.85).contains(&ratio) {
-        ((0.5926 * f32::from(ch0_data)) + (0.1185 * f32::from(ch1_data))) / als_gain / int_time
-    } else {
-        0.0
-    }
-}
-
-fn raw_to_lux_u32(ch1_data: u16, ch0_data: u16, gain: Gain, itime: IntegrationTime) -> u32 {
+fn raw_to_millilux(ch1_data: u16, ch0_data: u16, gain: Gain, itime: IntegrationTime) -> u32 {
+    // See: https://github.com/aniketpalu/LTR303/blob/main/LTR-303%20329_Appendix%20A%20Ver_1.0_22%20Feb%202013.pdf
     let ratio = (ch1_data as u32 * 1000).checked_div(ch0_data as u32 + ch1_data as u32);
     let als_gain = match gain {
         Gain::Gain1x => 1,

--- a/src/types.rs
+++ b/src/types.rs
@@ -95,8 +95,7 @@ fn raw_to_lux_u32(ch1_data: u16, ch0_data: u16, gain: Gain, itime: IntegrationTi
         _ => (0, 0),
     };
 
-    (((factors.0 * ch0_data as i32) as i64 + (factors.1 * ch1_data as i32) as i64) * 10
-        / als_gain as i64) as u32
+    (((factors.0 * ch0_data as i64) + (factors.1 * ch1_data as i64)) / als_gain as i64) as u32
         / int_time
 }
 
@@ -138,6 +137,6 @@ mod tests {
         );
 
         assert_eq!(lux, 9517.875);
-        assert_eq!(lux_u32, 9517_8752);
+        assert_eq!(lux_u32, 9517_875);
     }
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,11 +1,143 @@
+use crate::{Gain, IntegrationTime};
+
+/// Raw measurement data from the sensor.
 #[derive(Clone, Copy)]
 pub struct RawData {
     pub ch0_raw: u16,
     pub ch1_raw: u16,
 }
 
+/// A measurement from the sensor.
 #[derive(Clone, Copy)]
 pub struct LuxData {
-    pub lux_raw: RawData,
-    pub lux_phys: f32,
+    /// Raw sensor data.
+    pub(crate) lux_raw: RawData,
+
+    /// [`Gain`] this data was measured with.
+    pub(crate) gain: Gain,
+
+    /// [`IntegrationTime`] this data was measured with.
+    pub(crate) integration_time: IntegrationTime,
+}
+
+impl LuxData {
+    /// Raw value returned from the sensor
+    pub fn lux_raw(&self) -> &RawData {
+        &self.lux_raw
+    }
+
+    /// Value in Lux.
+    pub fn lux_phys(&self) -> f32 {
+        raw_to_lux(
+            self.lux_raw.ch1_raw,
+            self.lux_raw.ch0_raw,
+            self.gain,
+            self.integration_time,
+        )
+    }
+
+    /// Value in milli-Lux. Useful on platforms that do not have a floating
+    /// point unit.
+    pub fn lux_phys_u32(&self) -> u32 {
+        raw_to_lux_u32(
+            self.lux_raw.ch1_raw,
+            self.lux_raw.ch0_raw,
+            self.gain,
+            self.integration_time,
+        )
+    }
+}
+
+fn raw_to_lux(ch1_data: u16, ch0_data: u16, gain: Gain, itime: IntegrationTime) -> f32 {
+    let ratio = ch1_data as f32 / (ch0_data as f32 + ch1_data as f32);
+    let als_gain: f32 = gain.into();
+    let int_time: f32 = itime.into();
+
+    if ratio < 0.45 {
+        ((1.7743 * f32::from(ch0_data)) + (1.1059 * f32::from(ch1_data))) / als_gain / int_time
+    } else if (0.45..0.64).contains(&ratio) {
+        ((4.2785 * f32::from(ch0_data)) - (1.9548 * f32::from(ch1_data))) / als_gain / int_time
+    } else if (0.64..0.85).contains(&ratio) {
+        ((0.5926 * f32::from(ch0_data)) + (0.1185 * f32::from(ch1_data))) / als_gain / int_time
+    } else {
+        0.0
+    }
+}
+
+fn raw_to_lux_u32(ch1_data: u16, ch0_data: u16, gain: Gain, itime: IntegrationTime) -> u32 {
+    let ratio = ch1_data as u32 * 1000 / (ch0_data as u32 + ch1_data as u32);
+    let als_gain = match gain {
+        Gain::Gain1x => 1,
+        Gain::Gain2x => 2,
+        Gain::Gain4x => 4,
+        Gain::Gain8x => 8,
+        Gain::Gain48x => 48,
+        Gain::Gain96x => 96,
+    };
+
+    // scaled 10x
+    let int_time = match itime {
+        IntegrationTime::Ms50 => 5,
+        IntegrationTime::Ms100 => 10,
+        IntegrationTime::Ms150 => 15,
+        IntegrationTime::Ms200 => 20,
+        IntegrationTime::Ms250 => 25,
+        IntegrationTime::Ms300 => 30,
+        IntegrationTime::Ms350 => 35,
+        IntegrationTime::Ms400 => 40,
+    };
+
+    // scaled 10000x
+    let factors = match ratio {
+        0..=449 => (17743, 11059),
+        450..=639 => (42785, -19548),
+        640..=849 => (5926, 1185),
+        _ => (0, 0),
+    };
+
+    (((factors.0 * ch0_data as i32) as i64 + (factors.1 * ch1_data as i32) as i64) * 10
+        / als_gain as i64) as u32
+        / int_time
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn calculate_lux_from_raw() {
+        let ch0_data: u16 = 0x0000;
+        let ch1_data: u16 = 0xFFFF;
+
+        // First, test that CH1 >> CH0 returns 0 lux
+        let ltr303_config = crate::LTR303Config::default();
+
+        let lux = raw_to_lux(
+            ch1_data,
+            ch0_data,
+            ltr303_config.gain,
+            ltr303_config.integration_time,
+        );
+
+        assert_eq!(lux, 0.0);
+
+        // Then a normal random value testing ratio >= 0.45 && ratio < 0.64
+        let ch0_data: u16 = 0x1000;
+        let ch1_data: u16 = 0x1000;
+        let lux = raw_to_lux(
+            ch1_data,
+            ch0_data,
+            ltr303_config.gain,
+            ltr303_config.integration_time,
+        );
+        let lux_u32 = raw_to_lux_u32(
+            ch1_data,
+            ch0_data,
+            ltr303_config.gain,
+            ltr303_config.integration_time,
+        );
+
+        assert_eq!(lux, 9517.875);
+        assert_eq!(lux_u32, 9517_8752);
+    }
 }


### PR DESCRIPTION
Many microcontrollers (like ESP32s) do not have a floating point unit, therefore floating point operations have to be done in software. This is slow and consumes quite a lot of flash memory, so it's best avoided if possible.

This PR adds an option to calculate the physical lux value using only integer operations (using u64 for mulitplications internally, though). The resulting value is in milli-lux to cover the full range from 10mlux to 65k lux.

This also moves the calculation of the lux value to a method of `LuxData`, which in turn has to remember the gain and integration-time it was measured with. This allows code generation without floating point operations, as the `lux_phys` would be calculated even if not accessed (this is a guess, but I'd be fairly sure). It is a breaking change, but in my opinion for the better.

Also fixes a sign error in the floating point version of the lux formula.